### PR TITLE
FIX WhatsApp From Address + Message Sender

### DIFF
--- a/config/laraveltwilio.php
+++ b/config/laraveltwilio.php
@@ -16,6 +16,11 @@ return [
          * From phone number
          */
         'from' => env('TWILIO_FROM'),
+
+        /**
+         * From whatsapp phone number
+         */
+        'whatsapp_from' => env('TWILIO_WHATSAPP_FROM'),
     ],
     
     'senders' => [

--- a/src/LaravelTwilioMessage.php
+++ b/src/LaravelTwilioMessage.php
@@ -61,10 +61,10 @@ class LaravelTwilioMessage
     }
     
     /**
-     * @param array $data
+     * @param $data
      * @return LaravelTwilioMessage
      */
-    public function data(array $data)
+    public function data($data)
     {
         $this->data = $data;
         
@@ -72,10 +72,10 @@ class LaravelTwilioMessage
     }
 
     /**
-     * @param string $sender
+     * @param $sender
      * @return LaravelTwilioMessage
      */
-    public function sender(string $sender)
+    public function sender($sender)
     {
         $this->sender = $sender;
 

--- a/src/LaravelTwilioSender.php
+++ b/src/LaravelTwilioSender.php
@@ -51,7 +51,7 @@ class LaravelTwilioSender
      */
     public function send($to, LaravelTwilioMessage $message) {
         $payload = [
-            'from' => $message->from ?? $this->getDefaultFrom(),
+            'from' => $this->getFrom($message),
             'body' => $message->message,
         ];
 
@@ -75,7 +75,16 @@ class LaravelTwilioSender
      * Get default from phone number
      * @return mixed
      */
-    public function getDefaultFrom() {
+    public function getDefaultFrom($whatsApp) {
+        if ($whatsApp) {
+            return data_get(
+                $this->config, 'whatsapp_from',
+                data_get(
+                    $this->config, "default.whatsapp_from"
+                )
+            );
+        }
+
         return data_get(
             $this->config, 'from',
             data_get(
@@ -109,5 +118,16 @@ class LaravelTwilioSender
      */
     public static function registerValidPhoneForSandbox($validator) {
         self::$validPhoneForSandboxValidator = $validator;
+    }
+
+    /**
+     * In case of whatsapp, append whatsapp: as prefix
+     * @param LaravelTwilioMessage $message
+     * @return string
+     */
+    protected function getFrom(LaravelTwilioMessage $message) {
+        $from = $message->from ?? $this->getDefaultFrom($message->isWhatsApp);
+        
+        return $message->isWhatsApp ? ("whatsapp:" . $from) : $from;
     }
 }


### PR DESCRIPTION
- [x] From Address when sending WhatsApp message must have a `whatsapp:` prefix
- [x] Fix sender prototype for null sender